### PR TITLE
fix: correct team wiring, GORM preload, port format, and SSR crashes

### DIFF
--- a/apiserver/controllers/api_controllers.go
+++ b/apiserver/controllers/api_controllers.go
@@ -26,7 +26,7 @@ func NewAPIController(paster common.Paster, teamManager common.TeamManager, mgr 
 	return &APIController{
 		paster:      paster,
 		manager:     mgr,
-		teamManager: nil,
+		teamManager: teamManager,
 		cfg:         cfg,
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -280,7 +280,7 @@ func (a *APIServer) Validate() error {
 		}
 	}
 	if a.Port > 65535 || a.Port < 1 {
-		return fmt.Errorf("invalid port nr %q", a.Port)
+		return fmt.Errorf("invalid port nr %d", a.Port)
 	}
 
 	if err := a.JWTAuth.Validate(); err != nil {

--- a/paste/sql/teams.go
+++ b/paste/sql/teams.go
@@ -42,7 +42,7 @@ func (t *teamManager) getUserByUsernameOrEmail(userID string) (models.Users, err
 		queryString = "email = ?"
 	}
 
-	q := t.conn.Preload("Teams").Where(queryString, userID).First(&tmpUser)
+	q := t.conn.Where(queryString, userID).First(&tmpUser)
 	if q.Error != nil {
 		if errors.Is(q.Error, gorm.ErrRecordNotFound) {
 			return models.Users{}, gErrors.ErrNotFound
@@ -55,7 +55,7 @@ func (t *teamManager) getUserByUsernameOrEmail(userID string) (models.Users, err
 func (t *teamManager) getUser(userID uint) (models.Users, error) {
 	// TODO: abstract this into a common interface
 	var tmpUser models.Users
-	q := t.conn.Preload("Teams").Where("id = ?", userID).First(&tmpUser)
+	q := t.conn.Where("id = ?", userID).First(&tmpUser)
 	if q.Error != nil {
 		if errors.Is(q.Error, gorm.ErrRecordNotFound) {
 			return models.Users{}, gErrors.ErrNotFound

--- a/webui/svelte-app/src/routes/+page.svelte
+++ b/webui/svelte-app/src/routes/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import { page } from '$app/stores';
 	import { auth } from '$lib/stores/auth';
 	import { editorTheme } from '$lib/stores/editorTheme';
 	import { createPaste } from '$lib/api/pastes';
@@ -62,8 +64,8 @@
 	}
 
 	// Redirect if not authenticated
-	$: if (!$auth.isAuthenticated) {
-		const currentPath = encodeURIComponent(window.location.pathname);
+	$: if (browser && !$auth.isAuthenticated) {
+		const currentPath = encodeURIComponent($page.url.pathname);
 		goto(`/login?next=${currentPath}`);
 	}
 </script>

--- a/webui/svelte-app/src/routes/p/+page.svelte
+++ b/webui/svelte-app/src/routes/p/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page as appPage } from '$app/stores';
 	import { onMount } from 'svelte';
 	import { auth } from '$lib/stores/auth';
 	import { listPastes, searchPastes, deletePaste, updatePaste } from '$lib/api/pastes';
@@ -41,7 +42,7 @@
 
 	async function loadPastes() {
 		if (!$auth.token) {
-			const currentPath = encodeURIComponent(window.location.pathname);
+			const currentPath = encodeURIComponent($appPage.url.pathname);
 			goto(`/login?next=${currentPath}`);
 			return;
 		}
@@ -135,8 +136,8 @@
 	async function copyPasteUrl(paste: Paste, event: Event) {
 		event.stopPropagation();
 		const url = paste.public
-			? `${window.location.origin}/public/p/${paste.paste_id}`
-			: `${window.location.origin}/p/${paste.paste_id}`;
+			? `${$appPage.url.origin}/public/p/${paste.paste_id}`
+			: `${$appPage.url.origin}/p/${paste.paste_id}`;
 
 		try {
 			await copyToClipboard(url);

--- a/webui/svelte-app/src/routes/p/[id]/+page.svelte
+++ b/webui/svelte-app/src/routes/p/[id]/+page.svelte
@@ -26,7 +26,7 @@
 	onMount(async () => {
 		if (!$auth.token) {
 			// Redirect to login with next parameter
-			const currentPath = encodeURIComponent(window.location.pathname);
+			const currentPath = encodeURIComponent($page.url.pathname);
 			goto(`/login?next=${currentPath}`);
 			return;
 		}


### PR DESCRIPTION
## Summary

- **Team manager wired**: `NewAPIController` was hardcoding `teamManager: nil`, silently breaking every team endpoint at runtime.
- **Invalid GORM preload removed**: `getUser` and `getUserByUsernameOrEmail` in `teams.go` were calling `Preload("Teams")` on `models.Users`, which has no such association — causing all team operations to fail with a GORM error.
- **Port error format**: `config.go` used `%q` (quoted string) to format a port number integer; changed to `%d`.
- **SvelteKit SSR crash**: Three route pages referenced `window.location.*` directly, which panics during server-side rendering. Replaced with `$page.url.*` from `$app/stores` and guarded the auth redirect with SvelteKit's `browser` check.

## Test plan

- [ ] `go build -mod vendor -tags fts5 ./...` compiles cleanly
- [ ] Team create/list/delete endpoints return correct responses (were 500 before)
- [ ] Navigating to `/`, `/p`, and `/p/<id>` does not crash during SSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)