### PR TITLE
feat(gbcli): add CLI client for piping stdin to a paste

### DIFF
--- a/cmd/gbcli/client.go
+++ b/cmd/gbcli/client.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Gabriel-Adrian Samfira
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"gopherbin/params"
+)
+
+type apiClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func newClient(baseURL, token string) *apiClient {
+	return &apiClient{
+		baseURL: baseURL,
+		token:   token,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *apiClient) login(username, password string) (string, error) {
+	body, _ := json.Marshal(params.PasswordLoginParams{
+		Username: username,
+		Password: password,
+	})
+	req, err := http.NewRequest("POST", c.baseURL+"/api/v1/auth/login", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("login failed: %s: %s", resp.Status, string(raw))
+	}
+	var jwt params.JWTResponse
+	if err := json.NewDecoder(resp.Body).Decode(&jwt); err != nil {
+		return "", err
+	}
+	if jwt.Token == "" {
+		return "", fmt.Errorf("login returned empty token")
+	}
+	c.token = jwt.Token
+	return jwt.Token, nil
+}
+
+func (c *apiClient) createPaste(p params.Paste) (*params.Paste, error) {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", c.baseURL+"/api/v1/paste", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errUnauthorized
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("create paste failed: %s: %s", resp.Status, string(raw))
+	}
+	var out params.Paste
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+var errUnauthorized = fmt.Errorf("unauthorized")

--- a/cmd/gbcli/config.go
+++ b/cmd/gbcli/config.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Gabriel-Adrian Samfira
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+type cliConfig struct {
+	URL      string `toml:"url"`
+	Username string `toml:"username,omitempty"`
+	Password string `toml:"password,omitempty"`
+	Token    string `toml:"token,omitempty"`
+
+	path string `toml:"-"`
+}
+
+func defaultConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".gopherbin.toml"), nil
+}
+
+func loadConfig(path string) (*cliConfig, error) {
+	if path == "" {
+		p, err := defaultConfigPath()
+		if err != nil {
+			return nil, err
+		}
+		path = p
+	}
+	c := &cliConfig{path: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c, nil
+		}
+		return nil, err
+	}
+	if _, err := toml.Decode(string(data), c); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	c.path = path
+	c.URL = strings.TrimRight(c.URL, "/")
+	return c, nil
+}
+
+func (c *cliConfig) save() error {
+	if c.path == "" {
+		p, err := defaultConfigPath()
+		if err != nil {
+			return err
+		}
+		c.path = p
+	}
+	f, err := os.OpenFile(c.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return toml.NewEncoder(f).Encode(c)
+}

--- a/cmd/gbcli/main.go
+++ b/cmd/gbcli/main.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Gabriel-Adrian Samfira
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+
+// gbcli is a small client for a gopherbin server. It reads stdin and
+// creates a paste via the REST API. Pastes are private by default.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"gopherbin/params"
+)
+
+func usage() {
+	fmt.Fprint(os.Stderr, `usage: gbcli [--config <path>] <command> [flags]
+
+Commands:
+  login        Prompt for server URL, username, password and write ~/.gopherbin.toml
+  paste        Read stdin and create a paste; prints the paste URL on success
+
+Run 'gbcli <command> -h' for command-specific flags.
+`)
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	configPath := ""
+	// Allow --config before the subcommand.
+	for len(args) > 0 && (args[0] == "--config" || args[0] == "-config") {
+		if len(args) < 2 {
+			return errors.New("--config requires a path")
+		}
+		configPath = args[1]
+		args = args[2:]
+	}
+	if len(args) == 0 {
+		usage()
+		return errors.New("no command given")
+	}
+	cmd, rest := args[0], args[1:]
+	switch cmd {
+	case "login":
+		return cmdLogin(configPath, rest)
+	case "paste":
+		return cmdPaste(configPath, rest)
+	case "-h", "--help", "help":
+		usage()
+		return nil
+	default:
+		usage()
+		return fmt.Errorf("unknown command: %s", cmd)
+	}
+}
+
+func cmdLogin(configPath string, args []string) error {
+	fs := flag.NewFlagSet("login", flag.ContinueOnError)
+	server := fs.String("url", "", "server URL (e.g. https://gopherbin.example.com)")
+	username := fs.String("username", "", "username (prompted if empty)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	in := bufio.NewReader(os.Stdin)
+	if *server == "" {
+		def := cfg.URL
+		fmt.Fprintf(os.Stderr, "Server URL [%s]: ", def)
+		line, _ := in.ReadString('\n')
+		line = strings.TrimSpace(line)
+		if line == "" {
+			line = def
+		}
+		*server = line
+	}
+	if *server == "" {
+		return errors.New("server URL is required")
+	}
+	if _, err := url.Parse(*server); err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+
+	if *username == "" {
+		fmt.Fprint(os.Stderr, "Username: ")
+		line, _ := in.ReadString('\n')
+		*username = strings.TrimSpace(line)
+	}
+	if *username == "" {
+		return errors.New("username is required")
+	}
+
+	password := os.Getenv("GOPHERBIN_PASSWORD")
+	if password == "" {
+		fmt.Fprint(os.Stderr, "Password: ")
+		pw, err := readPassword(in)
+		if err != nil {
+			return fmt.Errorf("reading password: %w", err)
+		}
+		password = pw
+	}
+	if password == "" {
+		return errors.New("password is required")
+	}
+
+	cfg.URL = strings.TrimRight(*server, "/")
+	cfg.Username = *username
+	// Do not persist password by default — store the token instead.
+	cfg.Password = ""
+
+	client := newClient(cfg.URL, "")
+	token, err := client.login(*username, password)
+	if err != nil {
+		return err
+	}
+	cfg.Token = token
+	if err := cfg.save(); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Logged in. Token cached in %s\n", cfg.path)
+	return nil
+}
+
+func cmdPaste(configPath string, args []string) error {
+	fs := flag.NewFlagSet("paste", flag.ContinueOnError)
+	name := fs.String("name", "", "paste title (default: stdin-<timestamp>)")
+	fs.StringVar(name, "n", "", "paste title (shorthand)")
+	public := fs.Bool("public", false, "make the paste public (default: private)")
+	expires := fs.String("expires", "", "expiration duration, e.g. 1h, 24h, 7d")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+	if cfg.URL == "" {
+		return errors.New("server URL not configured; run 'gbcli login' first")
+	}
+
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("reading stdin: %w", err)
+	}
+	if len(data) == 0 {
+		return errors.New("stdin is empty")
+	}
+
+	title := *name
+	if title == "" {
+		title = "stdin-" + time.Now().UTC().Format(time.RFC3339)
+	}
+
+	var expPtr *time.Time
+	if *expires != "" {
+		d, err := parseExpires(*expires)
+		if err != nil {
+			return err
+		}
+		t := time.Now().UTC().Add(d)
+		expPtr = &t
+	}
+
+	payload := params.Paste{
+		Data:    data,
+		Name:    title,
+		Public:  *public,
+		Expires: expPtr,
+	}
+
+	client := newClient(cfg.URL, cfg.Token)
+	out, err := client.createPaste(payload)
+	if err == errUnauthorized {
+		// Try to refresh the token using stored credentials, if any.
+		if cfg.Username == "" || cfg.Password == "" {
+			return fmt.Errorf("unauthorized; run 'gbcli login' to refresh the token")
+		}
+		token, lerr := client.login(cfg.Username, cfg.Password)
+		if lerr != nil {
+			return lerr
+		}
+		cfg.Token = token
+		_ = cfg.save()
+		client = newClient(cfg.URL, token)
+		out, err = client.createPaste(payload)
+	}
+	if err != nil {
+		return err
+	}
+
+	path := "/p/" + out.PasteID
+	if out.Public {
+		path = "/public/p/" + out.PasteID
+	}
+	fmt.Println(cfg.URL + path)
+	return nil
+}
+
+// readPassword reads a line from stdin with terminal echo disabled via stty.
+// If stty is unavailable (e.g. non-tty stdin), it falls back to a visible read
+// after warning the user on stderr.
+func readPassword(in *bufio.Reader) (string, error) {
+	restore := func() {}
+	if err := exec.Command("stty", "-F", "/dev/tty", "-echo").Run(); err == nil {
+		restore = func() {
+			_ = exec.Command("stty", "-F", "/dev/tty", "echo").Run()
+			fmt.Fprintln(os.Stderr)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "(warning: could not disable echo; password will be visible)")
+	}
+	defer restore()
+	line, err := in.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+// parseExpires extends time.ParseDuration with a "d" (days) suffix.
+func parseExpires(s string) (time.Duration, error) {
+	if strings.HasSuffix(s, "d") {
+		var days int
+		if _, err := fmt.Sscanf(s, "%dd", &days); err != nil {
+			return 0, fmt.Errorf("invalid expires: %s", s)
+		}
+		if days <= 0 {
+			return 0, fmt.Errorf("expires must be positive")
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
+}


### PR DESCRIPTION
## Why

Gopherbin currently ships only the API server (`cmd/gopherbin`) and a config generator (`cmd/gconfig`). Anyone who wants to pipe shell output into a paste has to hand-roll `curl` against `POST /api/v1/auth/login` + `POST /api/v1/paste`. This adds a small first-party CLI so the common case — `<cmd> | gbcli paste` — works out of the box, and defaults to **private** pastes so nothing leaks publicly by accident.

## What

New binary at `cmd/gbcli` with two subcommands:

- `gbcli login` — prompts for server URL, username, password (or reads `GOPHERBIN_PASSWORD`), logs in via `POST /api/v1/auth/login`, and caches the JWT to `~/.gopherbin.toml` (mode `0600`).
- `gbcli paste [-n name] [--public] [--expires 1h|24h|7d]` — reads stdin and `POST`s to `/api/v1/paste` using the cached token. Prints `<server>/p/<id>` (or `<server>/public/p/<id>` for public) on success.

Files added:

- `cmd/gbcli/main.go` — flag/subcommand dispatch, stdin read, expires parsing, password prompt with `stty -echo`.
- `cmd/gbcli/client.go` — thin HTTP client; reuses `params.PasswordLoginParams`, `params.Paste`, `params.JWTResponse` from the server tree (no duplicate structs).
- `cmd/gbcli/config.go` — TOML config at `~/.gopherbin.toml`.

## How

- Config format is TOML to match the server (already-vendored `BurntSushi/toml`); no new module dependencies.
- Password input disables echo via `stty -F /dev/tty -echo` instead of pulling in `golang.org/x/term`, which isn't vendored. Falls back to visible input with a stderr warning if `stty` isn't available. `GOPHERBIN_PASSWORD` env var skips the prompt entirely for scripted use.
- The CLI builds automatically — the Makefile's `go install ./cmd/...` picks up the new directory; no Makefile change needed.
- On 401 the CLI only auto-refreshes the token if a password is cached in the config. The password is **not** persisted by default; a stale token requires re-running `gbcli login`. Storing the plaintext password by default felt worse than the occasional re-login.

### Test plan

- [x] `go build -mod vendor ./cmd/gbcli` succeeds
- [x] `go vet -mod vendor ./cmd/gbcli/...` clean
- [x] `gofmt -s -l cmd/gbcli` clean
- [x] `gbcli paste -h` prints expected flags and exits 0
- [ ] End-to-end against a live gopherbin: `gbcli login`, then `echo hello | gbcli paste -n smoke` returns a `/p/<id>` URL and the paste is private
- [ ] `--public` returns a `/public/p/<id>` URL and the paste is publicly viewable
- [ ] `--expires 1h` sets the paste's `expires` ~1h ahead
