### PR TITLE
feat(paste): allow editing expiration, language and visibility

### DIFF
--- a/apiserver/controllers/api_controllers.go
+++ b/apiserver/controllers/api_controllers.go
@@ -364,7 +364,7 @@ func (p *APIController) UpdatePasteHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	pasteInfo, err := p.paster.SetPrivacy(ctx, pasteID, pasteData.Public)
+	pasteInfo, err := p.paster.UpdatePaste(ctx, pasteID, pasteData)
 	if err != nil {
 		handleError(w, err)
 		return

--- a/params/request.go
+++ b/params/request.go
@@ -16,6 +16,8 @@ package params
 
 import (
 	"fmt"
+	"time"
+
 	"gopherbin/errors"
 	"gopherbin/util"
 
@@ -113,9 +115,23 @@ func (p PasswordLoginParams) Validate() error {
 	return nil
 }
 
-// UpdatePasteParams is the payload we can send to update a paste.
+// UpdatePasteParams is the payload we can send to update a paste. All fields
+// are optional; only fields explicitly set in the payload are applied.
 type UpdatePasteParams struct {
-	Public bool `json:"public"`
+	Public   *bool      `json:"public,omitempty"`
+	Expires  *time.Time `json:"expires,omitempty"`
+	Language *string    `json:"language,omitempty"`
+	// ClearExpiration removes the expiration date when true. Takes precedence
+	// over Expires.
+	ClearExpiration bool `json:"clear_expiration,omitempty"`
+}
+
+// Validate checks the update payload for obvious errors.
+func (u UpdatePasteParams) Validate() error {
+	if u.Language != nil && len(*u.Language) > 64 {
+		return errors.NewBadRequestError("language name too long")
+	}
+	return nil
 }
 
 // NewTeamParams holds information needed to create a new team.

--- a/paste/common/interface.go
+++ b/paste/common/interface.go
@@ -35,7 +35,7 @@ type Paster interface {
 	List(ctx context.Context, page int64, results int64) (paste params.PasteListResult, err error)
 	Search(ctx context.Context, query string, page int64, results int64) (paste params.PasteListResult, err error)
 	Delete(ctx context.Context, pasteID string) error
-	SetPrivacy(ctx context.Context, pasteID string, public bool) (params.Paste, error)
+	UpdatePaste(ctx context.Context, pasteID string, updateParams params.UpdatePasteParams) (params.Paste, error)
 	ShareWithUser(ctx context.Context, pasteID string, userID string) (params.TeamMember, error)
 	UnshareWithUser(ctx context.Context, pasteID string, userID string) error
 	ListShares(ctx context.Context, pasteID string) (params.PasteShareListResponse, error)

--- a/paste/sql/paste.go
+++ b/paste/sql/paste.go
@@ -672,12 +672,26 @@ func (p *paste) ListShares(ctx context.Context, pasteID string) (params.PasteSha
 	}, nil
 }
 
-func (p *paste) SetPrivacy(ctx context.Context, pasteID string, public bool) (params.Paste, error) {
+func (p *paste) UpdatePaste(ctx context.Context, pasteID string, updateParams params.UpdatePasteParams) (params.Paste, error) {
+	if err := updateParams.Validate(); err != nil {
+		return params.Paste{}, err
+	}
 	pst, err := p.get(ctx, pasteID)
 	if err != nil {
 		return params.Paste{}, errors.Wrap(err, "fetching paste")
 	}
-	pst.Public = public
+	if updateParams.Public != nil {
+		pst.Public = *updateParams.Public
+	}
+	if updateParams.Language != nil {
+		pst.Language = *updateParams.Language
+	}
+	if updateParams.ClearExpiration {
+		pst.Expires = nil
+	} else if updateParams.Expires != nil {
+		exp := *updateParams.Expires
+		pst.Expires = &exp
+	}
 	q := p.conn.Save(&pst)
 	if q.Error != nil {
 		return params.Paste{}, errors.Wrap(q.Error, "saving paste to DB")

--- a/webui/svelte-app/src/lib/types/paste.ts
+++ b/webui/svelte-app/src/lib/types/paste.ts
@@ -23,6 +23,9 @@ export interface PasteCreate {
 
 export interface PasteUpdate {
 	public?: boolean;
+	expires?: string | null;
+	language?: string;
+	clear_expiration?: boolean;
 }
 
 export interface PasteList {

--- a/webui/svelte-app/src/routes/p/+page.svelte
+++ b/webui/svelte-app/src/routes/p/+page.svelte
@@ -15,6 +15,7 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { formatApiError } from '$lib/utils/errors';
 	import { decodeBase64 } from '$lib/utils/base64';
+	import { extensionToLanguage } from '$lib/utils/syntax';
 	import type { Paste } from '$lib/types/paste';
 	import {
 		Eye,
@@ -25,8 +26,11 @@
 		Lock,
 		Trash2,
 		Search,
-		X
+		X,
+		Pencil
 	} from 'lucide-svelte';
+
+	const availableLanguages = Array.from(new Set(Object.values(extensionToLanguage))).sort();
 
 	let pastes: Paste[] = [];
 	let loading = true;
@@ -35,6 +39,12 @@
 	let totalPages = 1;
 	let maxResults = 20;
 	let deletingPaste: Paste | null = null;
+	let editingPaste: Paste | null = null;
+	let editLanguage = '';
+	let editExpires = '';
+	let editPublic = false;
+	let editSaving = false;
+	let editError = '';
 	let sharingPaste: { id: string; name: string } | null = null;
 	let copyTooltip: string | null = null;
 	let searchQuery = '';
@@ -125,6 +135,49 @@
 			loadPastes();
 		} catch (err) {
 			error = formatApiError(err);
+		}
+	}
+
+	function initEdit(paste: Paste, event: Event) {
+		event.stopPropagation();
+		editingPaste = paste;
+		editLanguage = paste.language || '';
+		editPublic = paste.public;
+		editError = '';
+		if (paste.expires) {
+			// Convert ISO string to value accepted by datetime-local input.
+			const d = new Date(paste.expires);
+			const pad = (n: number) => String(n).padStart(2, '0');
+			editExpires = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+		} else {
+			editExpires = '';
+		}
+	}
+
+	async function saveEdit() {
+		if (!editingPaste || !$auth.token) return;
+		editSaving = true;
+		editError = '';
+		try {
+			const payload: Record<string, unknown> = {
+				public: editPublic,
+				language: editLanguage
+			};
+			const original = editingPaste.expires ?? '';
+			if (!editExpires) {
+				if (original) {
+					payload.clear_expiration = true;
+				}
+			} else {
+				payload.expires = new Date(editExpires).toISOString();
+			}
+			await updatePaste(editingPaste.paste_id, payload, $auth.token);
+			editingPaste = null;
+			await loadPastes();
+		} catch (err) {
+			editError = formatApiError(err);
+		} finally {
+			editSaving = false;
 		}
 	}
 
@@ -277,6 +330,10 @@
 								{/if}
 							</div>
 
+							<IconButton title="Edit paste" on:click={(e) => initEdit(paste, e)}>
+								<Pencil class="w-4 h-4" />
+							</IconButton>
+
 							<IconButton title="Share paste" on:click={(e) => initShare(paste, e)}>
 								<Share2 class="w-4 h-4" />
 							</IconButton>
@@ -352,6 +409,58 @@
 		<div class="flex justify-end gap-2">
 			<Button on:click={() => (deletingPaste = null)} variant="secondary">Cancel</Button>
 			<Button on:click={confirmDelete} variant="danger">Delete</Button>
+		</div>
+	</div>
+</Modal>
+
+<!-- Edit Modal -->
+<Modal show={!!editingPaste} onClose={() => (editingPaste = null)}>
+	<div class="space-y-4">
+		<h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Edit paste</h2>
+		<p class="text-sm text-gray-600 dark:text-gray-400 truncate">
+			<strong>{editingPaste?.name}</strong>
+		</p>
+
+		{#if editError}
+			<div class="p-2 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-200 rounded-md text-sm">
+				{editError}
+			</div>
+		{/if}
+
+		<div class="space-y-3">
+			<label class="block">
+				<span class="text-sm text-gray-700 dark:text-gray-300">Language</span>
+				<select
+					bind:value={editLanguage}
+					class="mt-1 w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border-gray-300 dark:border-gray-600 text-sm"
+				>
+					{#each availableLanguages as lang}
+						<option value={lang}>{lang}</option>
+					{/each}
+				</select>
+			</label>
+
+			<label class="block">
+				<span class="text-sm text-gray-700 dark:text-gray-300">Expires</span>
+				<div class="flex gap-2 mt-1">
+					<input
+						type="datetime-local"
+						bind:value={editExpires}
+						class="flex-1 px-3 py-2 border rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border-gray-300 dark:border-gray-600 text-sm"
+					/>
+					<Button type="button" variant="secondary" on:click={() => (editExpires = '')}>Clear</Button>
+				</div>
+			</label>
+
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={editPublic} />
+				<span class="text-sm text-gray-700 dark:text-gray-300">Public</span>
+			</label>
+		</div>
+
+		<div class="flex justify-end gap-2">
+			<Button on:click={() => (editingPaste = null)} variant="secondary" disabled={editSaving}>Cancel</Button>
+			<Button on:click={saveEdit} variant="primary" disabled={editSaving}>Save</Button>
 		</div>
 	</div>
 </Modal>


### PR DESCRIPTION
## Why

Closes #36. Once a paste is created the only mutable property is its public/private flag. Users who pick the wrong language or forget to set an expiration have to delete and recreate the paste. This extends the edit path to cover expiration and language as well.

## What

Backend:
- `params/request.go` — `UpdatePasteParams` becomes a partial-update payload: `Public *bool`, `Expires *time.Time`, `Language *string`, plus a `ClearExpiration bool` flag. Added `Validate()` (length-cap on language).
- `paste/common/interface.go` — replaced `SetPrivacy` with `UpdatePaste(ctx, pasteID, UpdatePasteParams)`.
- `paste/sql/paste.go` — new `UpdatePaste` applies only the fields present in the payload; `ClearExpiration` wins over `Expires`.
- `apiserver/controllers/api_controllers.go` — `UpdatePasteHandler` now calls `UpdatePaste`.

Frontend:
- `lib/types/paste.ts` — `PasteUpdate` extended with `expires`, `language`, `clear_expiration`.
- `routes/p/+page.svelte` — added a pencil "Edit paste" action that opens a modal with a language dropdown (built from `extensionToLanguage` values), a `datetime-local` expiration field with a Clear button, and a public checkbox. Sends `clear_expiration: true` when the user clears a previously-set expiry.

## How

`encoding/json` collapses an absent field and an explicit `null` into the same `nil` pointer, so a `*time.Time` alone can't distinguish "leave alone" from "clear". A dedicated `ClearExpiration` flag is the simplest way to express the intent without a custom unmarshaller.

The issue suggested validating `Language` against `apiserver/controllers/languages.go`'s `LanguageMappings`, but the frontend stores editor-mode strings (`golang`, `c_cpp`, `text`, ...) which don't match that map's keys (display names like `Go`, `C++`), and create-time never enforced it either. Enforcing it now would reject every existing paste edit, so I capped length and left semantic validation out — worth a follow-up if a real allow-list is desired.

### Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `npx svelte-check` — 0 errors, 0 warnings
- [ ] `go test ./paste/...` — fails locally with `no such module: fts5` (sqlite build), unrelated to this change; verify on CI
- [ ] In the web UI, edit a paste: change language, set/clear/update expiration, toggle public — confirm the list refreshes with the new values

